### PR TITLE
Fix relative ascent link path

### DIFF
--- a/peaks.html
+++ b/peaks.html
@@ -258,7 +258,10 @@
         const cells = row.children;
         const linkEl = cells[idx.date]?.querySelector('a');
         let url = linkEl?.getAttribute('href') || '';
-        if (url && !url.startsWith('http')) url = new URL(url, SITE_ORIGIN).href;
+        if (url && !url.startsWith('http')) {
+          if (url.startsWith('ascent.aspx')) url = 'climber/' + url;
+          url = new URL(url, SITE_ORIGIN).href;
+        }
         return {
           peak: cells[idx.peak]?.innerText.trim() || '',
           elev: parseInt((cells[idx.elev]?.innerText || '').replace(/[^\d]/g, '')) || 0,


### PR DESCRIPTION
## Summary
- add `/climber/` prefix when forming ascent URLs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ce0544d1483338bf5a0a4f30b548d