### PR TITLE
Add viewport meta tag for mobile friendliness

### DIFF
--- a/peaks.html
+++ b/peaks.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Peak Timeline</title>
   <style>
     :root {


### PR DESCRIPTION
## Summary
- add `meta viewport` tag so mobile browsers display the page at device width

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683cf36f69cc8333890d9f66f075eb92