### PR TITLE
Fix toast line wrapping

### DIFF
--- a/peaks.html
+++ b/peaks.html
@@ -137,6 +137,7 @@
       color: #fff;
       font-size: 0.85rem;
       pointer-events: none;
+      white-space: nowrap;
       opacity: 0;
       transition: opacity 0.2s ease;
       backdrop-filter: blur(4px);


### PR DESCRIPTION
## Summary
- prevent scroll toast text from wrapping unnecessarily

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683cfe0aaed883338c6d5cccbe4f631f